### PR TITLE
fix: remove duplicate SolflareWalletAdapter from wallets array

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -35,7 +35,6 @@ const Context: FC<{ children: ReactNode }> = ({ children }) => {
             new SolflareWalletAdapter({ network }),
             new TorusWalletAdapter(),
             new LedgerWalletAdapter(),
-            new SolflareWalletAdapter({ network }),
         ],
         [network]
     );


### PR DESCRIPTION
The SolflareWalletAdapter was listed twice in the wallets configuration, which is redundant and could potentially cause issues. Removed the duplicate entry to ensure clean wallet adapter initialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)